### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(Sidplay2 REQUIRED)
 find_package(Resid REQUIRED)
 
@@ -22,8 +21,7 @@ set(SID_SOURCES src/SIDCodec.cpp)
 list(APPEND DEPLIBS ${SIDPLAY2_LIBRARIES}
                     ${RESID_LIBRARIES})
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/..
+include_directories(${KODI_INCLUDE_DIR}/..
                     ${RESID_INCLUDE_DIRS}
                     ${SIDPLAY2_INCLUDE_DIRS})
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-audiodecoder-sidplay
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev,
-               libkodiplatform-dev (>= 16.0.0), libsidplay2-dev,
+               libsidplay2-dev,
                libresid-builder-dev
 Standards-Version: 3.9.2
 Section: libs


### PR DESCRIPTION
The audiodecoder.sidplay binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.