### PR TITLE
Fix Windows build after C++20 update

### DIFF
--- a/depends/windows/sidplay2/0006-libsidplay-inherited.patch
+++ b/depends/windows/sidplay2/0006-libsidplay-inherited.patch
@@ -1,0 +1,26 @@
+--- sidplay-libs-2.1.1/libsidplay/include/sidplay/SmartPtr.h.old	2013-11-18 00:40:16.679173012 +0100
++++ sidplay-libs-2.1.1/libsidplay/include/sidplay/SmartPtr.h	2013-11-18 00:41:22.451176157 +0100
+@@ -211,16 +211,16 @@
+ 	{
+ 		if ( bufferLen >= 1 )
+ 		{
+-			pBufCurrent = ( bufBegin = buffer );
+-			bufEnd = bufBegin + bufferLen;
+-			bufLen = bufferLen;
+-			status = true;
++			this->pBufCurrent = ( this->bufBegin = buffer );
++			this->bufEnd = this->bufBegin + bufferLen;
++			this->bufLen = bufferLen;
++			this->status = true;
+ 		}
+ 		else
+ 		{
+-			pBufCurrent = bufBegin = bufEnd = 0;
+-			bufLen = 0;
+-			status = false;
++			this->pBufCurrent = this->bufBegin = this->bufEnd = 0;
++			this->bufLen = 0;
++			this->status = false;
+ 		}
+ 	}
+ };


### PR DESCRIPTION
Since C++20 update, Windows and Xbox build is broken.

The fix consists of adding a patch that is already present on the other platforms:

`depends/common/sidplay2/02-inherited.patch`